### PR TITLE
Context root path

### DIFF
--- a/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<jboss-web>  
+    <context-root>/</context-root>  
+</jboss-web>


### PR DESCRIPTION
This setting allows application deployment as it is, without the need of renaming your application filename as ROOT.was.